### PR TITLE
Unexpected NullPointerException in case if json data contains array.

### DIFF
--- a/src/main/java/com/fasterxml/jackson/jsonpath/JsonPath.java
+++ b/src/main/java/com/fasterxml/jackson/jsonpath/JsonPath.java
@@ -175,6 +175,7 @@ public class JsonPath {
         boolean inArrayContext = false;
 
         for (PathToken pathToken : tokenizer) {
+            if (node == null) return null;
             PathTokenFilter filter = pathToken.getFilter();
             node = filter.filter(node, contextFilters, inArrayContext);
             if (!inArrayContext) {


### PR DESCRIPTION
Consider the following code:

```
private final static String ARRAY_EXPAND = "[{\"parent\": \"ONE\", \"child\": {\"name\": \"NAME_ONE\"}}, [{\"parent\": \"TWO\", \"child\": {\"name\": \"NAME_TWO\"}}]]";

@Test
public void access_wrong_path_does_not_throw_exception() throws Exception {
    JsonPath.read(ARRAY_EXPAND, "$.some.key.that[1].does.not.exist");
}
```

Test case throws with NullPointerException. I think it shouldn't. Otherwise it is hard to distinguish errors from normal behavior.
